### PR TITLE
[Backport] Fix bug with retry connect and custom db port

### DIFF
--- a/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
+++ b/lib/internal/Magento/Framework/DB/Adapter/Pdo/Mysql.php
@@ -557,6 +557,15 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
                 ) {
                     $retry = true;
                     $triesCount++;
+                    
+                    /**
+                    * _connect() function does not allow port parameter, so put the port back with the host
+                    */
+                    if (!empty($this->_config['port'])) {
+                        $this->_config['host'] = implode(':', [$this->_config['host'], $this->_config['port']]);
+                        unset($this->_config['port']);
+                    }
+
                     $this->closeConnection();
                     $this->_connect();
                 }


### PR DESCRIPTION
Original Pull Request
magento#14435
Fix a bug in the MySQL adapter when using non standard port

Manual testing scenarios
Use a database config with port, e.g. localhost:3307
On first call to _connect(), the config['host'] parameter is split into config['host'] and config['port']
In the _query() function, a situation happens that is suitable for a retry (e.g. a "MySQL has gone away" error)
_connect() is called again
Expected result
Connection is reestablished and query tried again

Actual result
"Port must be configured within host parameter" exception

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. ...
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
